### PR TITLE
Better to specify source files instead of using GLOB option. 

### DIFF
--- a/PoseLib/CMakeLists.txt
+++ b/PoseLib/CMakeLists.txt
@@ -1,10 +1,48 @@
 # Set SOURCES variable
-file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cc)
+set(SOURCES
+    gp3p.cc
+    gp4ps.cc
+    p1p2ll.cc
+    p2p1ll.cc
+    p2p2pl.cc
+    p3ll.cc
+    p3p.cc
+    p4pf.cc
+    p5lp_radial.cc
+    p6lp.cc
+    ugp2p.cc
+    ugp3ps.cc
+    univariate.cc
+    up1p2pl.cc
+    up2p.cc
+    up4pl.cc
+)
 
 # Set HEADERS variable
-file(GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+set(HEADERS
+    gp3p.h
+    gp4ps.h
+    p1p2ll.h
+    p2p1ll.h
+    p2p2pl.h
+    p3ll.h
+    p3p.h
+    p4pf.h
+    p5lp_radial.h
+    p6lp.h
+    poselib.h
+    types.h
+    ugp2p.h
+    ugp3ps.h
+    univariate.h
+    up1p2pl.h
+    up2p.h
+    up4pl.h
+)
 
+#
 # re3q3 (included as part of the library)
+#
 include_directories(${CMAKE_SOURCE_DIR}/re3q3)
 set($SOURCES
 	re3q3/re3q3.cc


### PR DESCRIPTION
Issue #1 

Here the reasons:
    https://stackoverflow.com/questions/1027247/is-it-better-to-specify-source-files-with-glob-or-each-file-individually-in-cmak#1060061

Also it is not recommended in the cmake documentation:
    https://cmake.org/cmake/help/v3.4/command/file.html

> Note: We do not recommend using GLOB to collect a list of source files from your source tree. If no CMakeLists.txt file changes when a source is added or removed then the generated build system cannot know when to ask CMake to regenerate.
