### PR TITLE
C++11 cmake/compilation fix

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,7 +7,13 @@ add_executable(benchmark
     ${CMAKE_SOURCE_DIR}/re3q3/re3q3/sturm8.cc
 )
 
-target_link_libraries(benchmark ${LIBRARY_NAME} Eigen3::Eigen)
+target_link_libraries(benchmark PRIVATE ${LIBRARY_NAME} Eigen3::Eigen)
+
+set_target_properties(benchmark PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED YES
+  CXX_EXTENSIONS NO
+)
 
 install(
   TARGETS benchmark

--- a/cmake/LibraryConfig.cmake
+++ b/cmake/LibraryConfig.cmake
@@ -20,6 +20,12 @@ endif()
 # Target
 add_library(${LIBRARY_NAME} ${LIBRARY_TYPE} ${SOURCES} ${HEADERS})
 
+set_target_properties(${LIBRARY_NAME} PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED YES
+  CXX_EXTENSIONS NO
+)
+
 # Install library
 install(TARGETS ${LIBRARY_NAME}
   EXPORT ${PROJECT_EXPORT}


### PR DESCRIPTION
Got issues to compile the code with Apple Clang.
- MacOs Catalina 10.15.4 - AppleClang 11.0.3.11030032

The problem at compilation:
```
: error: in-class initialization of non-static data member is a C++11 extension
      [-Werror,-Wc++11-extensions]
    double alpha = 1.0; // either focal length or scale
... -> many more error
```

Proposed solution:
- Add cmake CXX11 feature for the Library and the Benchmark binary.
- CXX11 pre-requirement should propagate in the PoseLib target.