### PR TITLE
Make it work in Windows. Use CMake Registry

### DIFF
--- a/cmake/CMakeRegistry.cmake
+++ b/cmake/CMakeRegistry.cmake
@@ -1,0 +1,70 @@
+#
+# CMake Registry
+#
+#   Export package to CMake registry such that it can be easily found by
+#   CMake even if it has not been installed to a standard directory.
+#
+#   Note: installation folder is the default.
+#
+if( NOT (DEFINED CMAKE_REGISTRY_FOLDER) OR
+      (CMAKE_REGISTRY_FOLDER AND
+      NOT (CMAKE_REGISTRY_FOLDER STREQUAL "BUILD_FOLDER") ) )
+    set(CMAKE_REGISTRY_FOLDER "INSTALL_FOLDER"
+      CACHE STRING "Choose CMake registry folder." FORCE)
+endif()
+# Set the possible values for cmake-gui
+set_property(CACHE CMAKE_REGISTRY_FOLDER PROPERTY STRINGS
+  "BUILD_FOLDER" "INSTALL_FOLDER" "OFF")
+message(STATUS "CMAKE_REGISTRY_FOLDER: ${CMAKE_REGISTRY_FOLDER}.")
+
+
+# CMake Register (build directory)
+if(CMAKE_REGISTRY_FOLDER STREQUAL "BUILD_FOLDER")
+  export(PACKAGE ${PROJECT_NAME})
+endif()
+
+#
+# Register installed package with CMake
+#
+# This function adds an entry to the CMake registry for packages with the
+# path of the directory where the package configuration file of the installed
+# package is located in order to help CMake find the package in a custom
+# installation prefix. This differs from CMake's export(PACKAGE) command
+# which registers the build directory instead.
+#
+function (register_package PACKAGE_FOLDER)
+  if (NOT IS_ABSOLUTE "${PACKAGE_FOLDER}")
+    set (PACKAGE_FOLDER "${CMAKE_INSTALL_PREFIX}/${PACKAGE_FOLDER}")
+  endif ()
+
+  string (MD5 REGISTRY_ENTRY "${PACKAGE_FOLDER}")
+
+  if (WIN32)
+    install (CODE
+      "execute_process (
+         COMMAND reg add \"HKCU\\\\Software\\\\Kitware\\\\CMake\\\\Packages\\\\${PROJECT_NAME}\" /v \"${REGISTRY_ENTRY}\" /d \"${PACKAGE_FOLDER}\" /t REG_SZ /f
+         RESULT_VARIABLE RT
+         ERROR_VARIABLE  ERR
+         OUTPUT_QUIET
+       )
+       if (RT EQUAL 0)
+         message (STATUS \"Register:   Added HKEY_CURRENT_USER\\\\Software\\\\Kitware\\\\CMake\\\\Packages\\\\${PROJECT_NAME}\\\\${REGISTRY_ENTRY}\")
+       else ()
+         string (STRIP \"\${ERR}\" ERR)
+         message (STATUS \"Register:   Failed to add registry entry: \${ERR}\")
+       endif ()"
+    )
+  elseif (IS_DIRECTORY "$ENV{HOME}")
+    file (WRITE "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-registry-entry" "${PACKAGE_FOLDER}")
+    install (
+      FILES       "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-registry-entry"
+      DESTINATION "$ENV{HOME}/.cmake/packages/${PROJECT_NAME}"
+      RENAME      "${REGISTRY_ENTRY}"
+    )
+  endif ()
+endfunction ()
+
+# CMake Register (install directory)
+if(CMAKE_REGISTRY_FOLDER STREQUAL "INSTALL_FOLDER")
+  register_package(${INSTALL_CMAKE_DIR})
+endif ()

--- a/cmake/LibraryConfig.cmake
+++ b/cmake/LibraryConfig.cmake
@@ -9,10 +9,9 @@ endif()
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to 'Release'.")
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 endif()
-# Set the possible values of build type for cmake-gui
+# Possible values of build type for cmake-gui
 if(DEFINED CMAKE_BUILD_TYPE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")

--- a/cmake/LibraryConfig.cmake
+++ b/cmake/LibraryConfig.cmake
@@ -11,11 +11,13 @@ endif()
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Release'.")
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-
-  # Set the possible values of build type for cmake-gui
+endif()
+# Set the possible values of build type for cmake-gui
+if(DEFINED CMAKE_BUILD_TYPE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
+message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}.")
 
 # Target
 add_library(${LIBRARY_NAME} ${LIBRARY_TYPE} ${SOURCES} ${HEADERS})
@@ -39,20 +41,20 @@ configure_file(version.h.in
   "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
 set(HEADERS ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 
-# Generate 'poselib.h' automatically
-file(GLOB HEADER_FILES ${CMAKE_SOURCE_DIR}/PoseLib/*.h)
+# Generate '${PROJECT_NAME_LOWERCASE}.h' automatically
+file(GLOB HEADER_FILES ${CMAKE_SOURCE_DIR}/${LIBRARY_NAME}/*.h)
 foreach(file ${HEADER_FILES})
   # get basename of each header file
   get_filename_component(basename ${file} NAME)
 
-  # append '#include <...>' to the 'poselib.h' file
+  # append '#include <...>' to the '${PROJECT_NAME_LOWERCASE}.h' file
   # ToDo: set(...) creates a list separated with ';'. Find a different way.
   set(LIB_INCLUDES_STRING ${LIB_INCLUDES_STRING} "#include <PoseLib/${basename}>\n")
 endforeach(file)
 string(REPLACE ";" "" LIB_INCLUDES_STRING "${LIB_INCLUDES_STRING}")
-configure_file(poselib.h.in
+configure_file(${PROJECT_NAME_LOWERCASE}.h.in
   "${CMAKE_CURRENT_BINARY_DIR}/poselib.h" @ONLY)
-set(HEADERS ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/poselib.h)
+set(HEADERS ${HEADERS} ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME_LOWERCASE}.h)
 
 # Install headers
 install(FILES ${HEADERS}

--- a/cmake/SetEnv.cmake
+++ b/cmake/SetEnv.cmake
@@ -9,34 +9,30 @@ set(PATCH_VERSION 0)
 set(PROJECT_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
 
 # INSTALL_LIB_DIR
-set(INSTALL_LIB_DIR lib
-    CACHE PATH "Relative installation path for libraries")
+set(INSTALL_LIB_DIR lib)
 
 # INSTALL_BIN_DIR
-set(INSTALL_BIN_DIR bin
-    CACHE PATH "Relative installation path for executables")
+set(INSTALL_BIN_DIR bin)
 
 # INSTALL_INCLUDE_DIR
-set(INSTALL_INCLUDE_DIR include
-    CACHE PATH "Relative installation path for header files")
+set(INSTALL_INCLUDE_DIR include)
 
 # INSTALL_CMAKE_DIR
-if(WIN32 AND NOT CYGWIN)
-  set(DEF_INSTALL_CMAKE_DIR cmake)
-else()
-  set(DEF_INSTALL_CMAKE_DIR lib/cmake/${PROJECT_NAME})
-endif()
-set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR}
-    CACHE PATH "Relative instalation path for CMake files")
+set(INSTALL_CMAKE_DIR lib/cmake/${PROJECT_NAME})
 
 # Convert relative path to absolute path (needed later on)
 foreach(substring LIB BIN INCLUDE CMAKE)
   set(var INSTALL_${substring}_DIR)
-  if(NOT IS_ABSOLUTE ${${var}})
-    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+
+  set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_PREFIX})
+    set(${var} "${CMAKE_BINARY_DIR}/${${var}}")
+    get_filename_component(${var} "${${var}}" ABSOLUTE)
   endif()
+
   message(STATUS "${var}: "  "${${var}}")
 endforeach()
+message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}.")
 
 # Set up include-directories
 include_directories(
@@ -63,3 +59,6 @@ set(PROJECT_CMAKE_FILES ${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY})
 
 # The RPATH to be used when installing
 set(CMAKE_INSTALL_RPATH ${INSTALL_LIB_DIR})
+
+# CMake Registry
+include(${CMAKE_SOURCE_DIR}/cmake/CMakeRegistry.cmake)


### PR DESCRIPTION
Issue #1 

The installation of the library in Windows was failing. This should fix the problem.

Now it is also find the library using the CMake Registry.

I need to update the README in how to compile/install in windows, but it should be something like this:
```
cmake ..
cmake --build . --config Release --target install -j30
```

It is possible to use cmake generators, for instance, `cmake .. -G Ninja`.

Also I would need to talk about the new option: `CMAKE_REGISTRY_FOLDER`

