### PR TITLE
Add new relative pose solvers (8pt, 3ptUprightPlanar)

### DIFF
--- a/PoseLib/CMakeLists.txt
+++ b/PoseLib/CMakeLists.txt
@@ -11,12 +11,14 @@ set(SOURCES
     p5lp_radial.cc
     p6lp.cc
     ugp2p.cc
-    ugp3ps.cc  
+    ugp3ps.cc
     up1p2pl.cc
     up2p.cc
     up4pl.cc
     ugp4pl.cc
     relpose_upright_3pt.cc
+    relpose_upright_planar_3pt.cc
+    relpose_8pt.cc
     gen_relpose_upright_4pt.cc
     misc/qep.cc
     misc/univariate.cc
@@ -36,12 +38,14 @@ set(HEADERS
     p6lp.h
     types.h
     ugp2p.h
-    ugp3ps.h    
+    ugp3ps.h
     up1p2pl.h
     up2p.h
     up4pl.h
     ugp4pl.h
     relpose_upright_3pt.h
+    relpose_upright_planar_3pt.h
+    relpose_8pt.h
     gen_relpose_upright_4pt.h
     misc/qep.h
     misc/univariate.h

--- a/PoseLib/relpose_8pt.cc
+++ b/PoseLib/relpose_8pt.cc
@@ -1,0 +1,135 @@
+// Copyright (c) 2020, Pierre Moulon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of the copyright holder nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "relpose_8pt.h"
+#include <array>
+
+/**
+ * Build a 9 x n matrix from bearing vector matches, where each row is equivalent to the
+ * equation x'T*F*x = 0 for a single correspondence pair (x', x).
+ *
+ * Note that this does not resize the matrix A; it is expected to have the
+ * appropriate size already (n x 9).
+ */
+void encode_epipolar_equation(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, Eigen::Matrix<double, Eigen::Dynamic, 9> *A) {
+  assert(x1.size() == x2.size());
+  assert(A->col() == 9);
+  assert(A->row() == x1.size());
+  for (size_t i = 0; i < x1.size(); ++i) {
+    A->row(i) <<
+      x2[i].x() * x1[i].transpose(),
+      x2[i].y() * x1[i].transpose(),
+      x2[i].z() * x1[i].transpose();
+  }
+}
+
+void pose_lib::essential_matrix_8pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, Eigen::Matrix3d *essential_matrix) {
+
+  assert(8 <= x1.cols());
+  assert(x1.rows() == x2.rows());
+  assert(x1.cols() == x2.cols());
+
+  using MatX9 = Eigen::Matrix<double, Eigen::Dynamic, 9>;
+  MatX9 epipolar_constraint(x1.size(), 9);
+  epipolar_constraint.fill(0.0);
+  encode_epipolar_equation(x1, x2, &epipolar_constraint);
+
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 9, 9>> solver
+    (epipolar_constraint.transpose() * epipolar_constraint);
+  using RMat3 = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>;
+  Eigen::Matrix3d E = Eigen::Map<const RMat3>(solver.eigenvectors().leftCols<1>().data());
+
+  // Find the closest essential matrix to E in frobenius norm
+  // E = UD'VT
+  if (x1.size() > 8) {
+    Eigen::JacobiSVD<Eigen::Matrix3d> USV(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    Eigen::Vector3d d = USV.singularValues();
+    const double a = d[0];
+    const double b = d[1];
+    d << (a + b) / 2., (a + b) / 2., 0.0;
+    E = USV.matrixU() * d.asDiagonal() * USV.matrixV().transpose();
+  }
+  (*essential_matrix) = E;
+}
+
+void pose_lib::motion_from_essential(const Eigen::Matrix3d &E, pose_lib::CameraPoseVector *relative_poses) {
+  Eigen::JacobiSVD<Eigen::Matrix3d> USV(E, Eigen::ComputeFullU|Eigen::ComputeFullV);
+  Eigen::Matrix3d U =  USV.matrixU();
+  Eigen::Matrix3d Vt = USV.matrixV().transpose();
+
+  // Last column of U is undetermined since d = (a a 0).
+  if (U.determinant() < 0) {
+    U.col(2) *= -1;
+  }
+  // Last row of Vt is undetermined since d = (a a 0).
+  if (Vt.determinant() < 0) {
+    Vt.row(2) *= -1;
+  }
+
+  Eigen::Matrix3d W;
+  W << 0, -1,  0,
+       1,  0,  0,
+       0,  0,  1;
+
+  const Eigen::Matrix3d U_W_Vt = U * W * Vt;
+  const Eigen::Matrix3d U_Wt_Vt = U * W.transpose() * Vt;
+
+  const std::array<Eigen::Matrix3d, 2> R{{U_W_Vt, U_Wt_Vt}};
+  const std::array<Eigen::Vector3d, 2> t{{U.col(2), -U.col(2)}};
+  if (relative_poses)
+  {
+    relative_poses->clear();
+    relative_poses->reserve(4);
+    pose_lib::CameraPose pose;
+    pose.R = R[0].transpose();
+    pose.t = -R[0].transpose() * t[0];
+    relative_poses->emplace_back(pose);
+
+    pose.R = R[1].transpose();
+    pose.t = -R[1].transpose() * t[1];
+    relative_poses->emplace_back(pose);
+
+    pose.R = R[0].transpose();
+    pose.t = -R[0].transpose() * t[1];
+    relative_poses->emplace_back(pose);
+
+    pose.R = R[1].transpose();
+    pose.t = -R[1].transpose() * t[0];
+    relative_poses->emplace_back(pose);
+  }
+}
+
+int pose_lib::relpose_8pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, CameraPoseVector *output) {
+
+  Eigen::Matrix3d essential_matrix;
+  essential_matrix_8pt(x1, x2, &essential_matrix);
+  // Generate plausible relative motion from E
+  output->clear();
+  pose_lib::motion_from_essential(essential_matrix, output);
+  return output->size();
+}

--- a/PoseLib/relpose_8pt.h
+++ b/PoseLib/relpose_8pt.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2020, Pierre Moulon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of the copyright holder nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include "types.h"
+#include <Eigen/Dense>
+
+namespace pose_lib {
+
+// Relative pose from eight to n bearing vector correspondences.
+// Port from OpenMVG (Essential_matrix computation then decomposition in 4 pose [R|t]).
+int relpose_8pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, CameraPoseVector *output);
+
+// Computation of essential matrix from eight to n bearing vector correspondences.
+// See page 294 in [HZ] Result 11.1.
+// [HZ] Multiple View Geometry - Richard Hartley, Andrew Zisserman - second edition
+// Port from OpenMVG
+void essential_matrix_8pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, Eigen::Matrix3d * essential_matrix);
+
+/**
+ * @brief Given an essential matrix computes the 2 rotations and the 2 translations
+ * that can generate four possible motions.
+ * @param E Essential matrix
+ * @param[out] relative_poses The 4 possible relative poses
+ * @ref Multiple View Geometry - Richard Hartley, Andrew Zisserman - second edition
+ * @see HZ 9.7 page 259 (Result 9.19)
+ */
+void motion_from_essential(const Eigen::Matrix3d &E, pose_lib::CameraPoseVector *relative_poses);
+
+}; // namespace pose_lib

--- a/PoseLib/relpose_upright_planar_3pt.cc
+++ b/PoseLib/relpose_upright_planar_3pt.cc
@@ -1,0 +1,57 @@
+// Copyright (c) 2020, Pierre Moulon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of the copyright holder nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "relpose_upright_planar_3pt.h"
+#include "relpose_8pt.h"
+
+int pose_lib::relpose_upright_planar_3pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, CameraPoseVector *output) {
+
+  // Build the action matrix -> see (6,7) in the paper
+  Eigen::Matrix<double, 3, 4> A;
+  for (const int i : {0,1,2})
+  {
+    const auto & bearing_a_i = x1[i];
+    const auto & bearing_b_i = x2[i];
+    A.row(i) <<
+         bearing_a_i.x() * bearing_b_i.y(), -bearing_a_i.z() * bearing_b_i.y(),
+        -bearing_b_i.x() * bearing_a_i.y(), -bearing_b_i.z() * bearing_a_i.y();
+  }
+
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 4, 4>> solver(A.transpose() * A);
+  const Eigen::Vector4d nullspace = solver.eigenvectors().leftCols<1>();
+
+  Eigen::Matrix3d essential_matrix = Eigen::Matrix3d::Zero(); // see (3) in the paper
+  essential_matrix(0, 1) =   nullspace(2);
+  essential_matrix(1, 0) = - nullspace(0);
+  essential_matrix(1, 2) =   nullspace(1);
+  essential_matrix(2, 1) =   nullspace(3);
+
+  output->clear();
+  pose_lib::motion_from_essential(essential_matrix, output);
+  return output->size();
+}

--- a/PoseLib/relpose_upright_planar_3pt.h
+++ b/PoseLib/relpose_upright_planar_3pt.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2020, Pierre Moulon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of the copyright holder nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include "types.h"
+#include <Eigen/Dense>
+
+namespace pose_lib {
+
+/**
+ * Three-point algorithm for solving for the essential matrix from bearing
+ * vector correspondences assuming upright images.
+ * Implementation of [1] section 3.3. Linear 3-point Algorithm
+ * Note: this is an approximate solver, not a minimal solver
+ *
+ * [1] "Fast and Reliable Minimal Relative Pose Estimation under Planar Motion"
+ * Sunglok Choi, Jong-Hwan Kim, 2018
+ *
+ * [2] Street View Goes Indoors: Automatic Pose Estimation From Uncalibrated Unordered Spherical Panoramas.
+ * Mohamed Aly and Jean-Yves Bouguet.
+ * IEEE Workshop on Applications of Computer Vision (WACV), Colorado, January 2012.
+ *
+ * Comment [2] and [1] propose both a Direct Linear Method using 3 correspondences.
+ * Note that they are using gravity axis and that [1] provides more details about the fact that
+ * the linear formulation is not a minimal solver since it cannot enforce the
+ * "Pythagorean" identity on sin^2(t) + cos^2(t) = 1
+ *
+ * Reimplementation from OpenMVG to PoseLib
+ */
+int relpose_upright_planar_3pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Eigen::Vector3d> &x2, CameraPoseVector *output);
+
+}; // namespace pose_lib

--- a/benchmark/benchmark.cc
+++ b/benchmark/benchmark.cc
@@ -137,7 +137,7 @@ void print_runtime(double runtime_ns) {
   }
 }
 
-void display_result(std::vector<pose_lib::BenchmarkResult> &results) {
+void display_result(const std::vector<pose_lib::BenchmarkResult> &results) {
 
   int w = 13;
   // display header
@@ -153,7 +153,7 @@ void display_result(std::vector<pose_lib::BenchmarkResult> &results) {
 
   int prec = 6;
 
-  for (pose_lib::BenchmarkResult &result : results) {
+  for (const pose_lib::BenchmarkResult &result : results) {
     double num_tests = static_cast<double>(result.instances_);
     double solutions = result.solutions_ / num_tests;
     double valid_sols = result.valid_solutions_ / static_cast<double>(result.solutions_) * 100.0;
@@ -180,7 +180,7 @@ int main() {
   options.camera_fov_ = 120; // Wide
 
   double tol = 1e-6;
-  
+
   // P3P
   pose_lib::ProblemOptions p3p_opt = options;
   p3p_opt.n_point_point_ = 3;
@@ -193,7 +193,7 @@ int main() {
   gp3p_opt.n_point_line_ = 0;
   gp3p_opt.generalized_ = true;
   results.push_back(pose_lib::benchmark<pose_lib::SolverGP3P>(1e4, gp3p_opt, tol));
-  
+
   // gP4Ps
   pose_lib::ProblemOptions gp4p_opt = options;
   gp4p_opt.n_point_point_ = 4;
@@ -201,7 +201,7 @@ int main() {
   gp4p_opt.generalized_ = true;
   gp4p_opt.unknown_scale_ = true;
   results.push_back(pose_lib::benchmark<pose_lib::SolverGP4PS>(1e4, gp4p_opt, tol));
-  
+
   // gP4Ps Quasi-degenerate case (same 3D point observed twice)
   gp4p_opt.generalized_duplicate_obs_ = true;
   gp4p_opt.additional_name_ = "(Deg.)";
@@ -254,7 +254,7 @@ int main() {
   up2p_opt.n_point_line_ = 0;
   up2p_opt.upright_ = true;
   results.push_back(pose_lib::benchmark<pose_lib::SolverUP2P>(1e6, up2p_opt, tol));
- 
+
   // uGP2P
   pose_lib::ProblemOptions ugp2p_opt = options;
   ugp2p_opt.n_point_point_ = 2;
@@ -293,21 +293,32 @@ int main() {
   ugp4pl_opt.upright_ = true;
   ugp4pl_opt.generalized_ = true;
   results.push_back(pose_lib::benchmark<pose_lib::SolverUGP4PL>(1e3, ugp4pl_opt, tol));
-  
+
 
   // Relative Pose Upright
   pose_lib::ProblemOptions relupright3pt_opt = options;
   relupright3pt_opt.n_point_point_ = 3;
-  relupright3pt_opt.upright_ = true;  
+  relupright3pt_opt.upright_ = true;
   results.push_back(pose_lib::benchmark_relative<pose_lib::SolverRelUpright3pt>(1e3, relupright3pt_opt, tol));
 
   // Generalized Relative Pose Upright
   pose_lib::ProblemOptions genrelupright4pt_opt = options;
-  genrelupright4pt_opt.n_point_point_ = 4;  
+  genrelupright4pt_opt.n_point_point_ = 4;
   genrelupright4pt_opt.upright_ = true;
   genrelupright4pt_opt.generalized_ = true;
   results.push_back(pose_lib::benchmark_relative<pose_lib::SolverGenRelUpright4pt>(1e3, genrelupright4pt_opt, tol));
 
+  // Relative Pose 8pt
+  pose_lib::ProblemOptions rel8pt_opt = options;
+  rel8pt_opt.n_point_point_ = 8;
+  results.push_back(pose_lib::benchmark_relative<pose_lib::SolverRel8pt>(1e3, rel8pt_opt, tol));
+
+  // Relative Pose Upright Planar 3pt
+  pose_lib::ProblemOptions reluprightplanar3pt_opt = options;
+  reluprightplanar3pt_opt.n_point_point_ = 3;
+  reluprightplanar3pt_opt.upright_ = true;
+  reluprightplanar3pt_opt.planar_ = true;
+  results.push_back(pose_lib::benchmark_relative<pose_lib::SolverRelUprightPlanar3pt>(1e3, reluprightplanar3pt_opt, tol));
 
   display_result(results);
 

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -151,19 +151,35 @@ struct SolverUGP4PL {
 
 
 struct SolverRelUpright3pt {
-    static inline int solve(const RelativePoseProblemInstance& instance, pose_lib::CameraPoseVector* solutions) {
-        return relpose_upright_3pt(instance.x1_, instance.x2_, solutions);
-    }
-    typedef CalibPoseValidator validator;
-    static std::string name() { return "RelUpright3pt"; }
+  static inline int solve(const RelativePoseProblemInstance& instance, pose_lib::CameraPoseVector* solutions) {
+    return relpose_upright_3pt(instance.x1_, instance.x2_, solutions);
+  }
+  typedef CalibPoseValidator validator;
+  static std::string name() { return "RelUpright3pt"; }
 };
 
 struct SolverGenRelUpright4pt {
-    static inline int solve(const RelativePoseProblemInstance& instance, pose_lib::CameraPoseVector* solutions) {
-        return gen_relpose_upright_4pt(instance.p1_, instance.x1_, instance.p2_, instance.x2_, solutions);
-    }
-    typedef CalibPoseValidator validator;
-    static std::string name() { return "GenRelUpright4pt"; }
+  static inline int solve(const RelativePoseProblemInstance& instance, pose_lib::CameraPoseVector* solutions) {
+    return gen_relpose_upright_4pt(instance.p1_, instance.x1_, instance.p2_, instance.x2_, solutions);
+  }
+  typedef CalibPoseValidator validator;
+  static std::string name() { return "GenRelUpright4pt"; }
+};
+
+struct SolverRel8pt {
+  static inline int solve(const RelativePoseProblemInstance& instance, pose_lib::CameraPoseVector* solutions) {
+    return relpose_8pt(instance.x1_, instance.x2_, solutions);
+  }
+  typedef CalibPoseValidator validator;
+  static std::string name() { return "Rel8pt"; }
+};
+
+struct SolverRelUprightPlanar3pt {
+  static inline int solve(const RelativePoseProblemInstance& instance, pose_lib::CameraPoseVector* solutions) {
+    return relpose_upright_planar_3pt(instance.x1_, instance.x2_, solutions);
+  }
+  typedef CalibPoseValidator validator;
+  static std::string name() { return "RelUprightPlanar3pt"; }
 };
 
 } // namespace pose_lib

--- a/benchmark/problem_generator.h
+++ b/benchmark/problem_generator.h
@@ -46,7 +46,7 @@ public:
     std::vector<Eigen::Vector3d> x1_;
 
     std::vector<Eigen::Vector3d> p2_;
-    std::vector<Eigen::Vector3d> x2_;   
+    std::vector<Eigen::Vector3d> x2_;
 };
 
 
@@ -83,6 +83,7 @@ struct ProblemOptions {
   int n_line_point_ = 0;
   int n_line_line_ = 0;
   bool upright_ = false;
+  bool planar_ = false;
   bool generalized_ = false;
   bool generalized_duplicate_obs_ = false;
   bool unknown_scale_ = false;
@@ -95,7 +96,7 @@ struct ProblemOptions {
   std::string additional_name_ = "";
 };
 
-void set_random_pose(CameraPose &pose, bool upright);
+void set_random_pose(CameraPose &pose, bool upright, bool planar);
 
 void generate_abspose_problems(int n_problems, std::vector<AbsolutePoseProblemInstance> *problem_instances, const ProblemOptions &options);
 void generate_relpose_problems(int n_problems, std::vector<RelativePoseProblemInstance>* problem_instances, const ProblemOptions& options);


### PR DESCRIPTION
- Add option to problem generator to constraint the camera on a plane

- Add new relative pose solvers:
  - relpose_upright_planar_3pt (Essential matrix on the plane).
     - It could be even more, optimized for [R|t] decomposition. See [Fast and Reliable Minimal Relative Pose Estimation under Planar Motion](http://rit.kaist.ac.kr/home/International_Journal?action=AttachFile&do=get&target=paper_0404.pdf). Need to decompose cos(a-b) to retrieve a and b. @vlarsson perhaps you know the trick to ease this (see equation (6) -> equation (2)).
  - relpose_8pt (Essential matrix)

- Fix various space/new line alignment

@vlarsson Please review and comment if I need to change anything (code style, optimization, ...)