### PR TITLE
Conditional compilation for benchmark.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,16 @@ find_package(Eigen3 REQUIRED)
 add_subdirectory(${LIBRARY_FOLDER})
 
 # Benchmark
-add_subdirectory(benchmark)
+option(WITH_BENCHMARK "Build benchmark example." OFF)
+if(WITH_BENCHMARK)
+	add_subdirectory(benchmark)
+endif()
 
 # Compilation options
 if(MSVC)
 	target_compile_options(${LIBRARY_NAME} PRIVATE /bigobj /fp:fast)
-	target_compile_options(benchmark PRIVATE /bigobj /fp:fast)
 else()
 	target_compile_options(${LIBRARY_NAME} PRIVATE
 		-march=native -Wall -Werror -Wno-sign-compare
 	 	-Wno-unused-variable -ffast-math)
-	target_compile_options(benchmark PRIVATE
-		-march=native -Wall -Werror -Wno-sign-compare
-		-Wno-unused-variable -ffast-math)
 endif()

--- a/README.md
+++ b/README.md
@@ -162,7 +162,17 @@ Uninstall library:
 
     > make uninstall
 
-### Use library (as dependency) in an external project.
+
+## Benchmark
+
+Conditional compilation of `benchmark` binary is controlled by `WITH_BENCHMARK` option. Default if OFF (without benchmark).
+
+Add `-DWITH_BENCHMARK=ON` to cmake to activate.
+
+    > cmake -DWITH_BENCHMARK=ON ..
+
+
+## Use library (as dependency) in an external project.
 
     cmake_minimum_required(VERSION 3.13)
     project(Foo)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -16,3 +16,12 @@ install(
   RUNTIME DESTINATION bin
   COMPONENT "${INSTALL_BIN_DIR}"
 )
+
+# Compilation options
+if(MSVC)
+  target_compile_options(benchmark PRIVATE /bigobj /fp:fast)
+else()
+  target_compile_options(benchmark PRIVATE
+    -march=native -Wall -Werror -Wno-sign-compare
+    -Wno-unused-variable -ffast-math)
+endif()


### PR DESCRIPTION
`WITH_BENCHMARK` option controls if `benchmark` binary is compiled or not.
Default if without benchmark.

Add `-DWITH_BENCHMARK=ON` to cmake to activate.

```
# Benchmark
option(WITH_BENCHMARK "Build benchmark example." OFF)
if(WITH_BENCHMARK)
	add_subdirectory(benchmark)
endif()
```