### PR TITLE
Added gen_relpose_6pt in pybind

### DIFF
--- a/pybind/pyposelib.cpp
+++ b/pybind/pyposelib.cpp
@@ -211,6 +211,15 @@ std::vector<CameraPose> gen_relpose_upright_4pt_wrapper(const std::vector<Eigen:
     return output;
 }
 
+std::vector<CameraPose> gen_relpose_6pt_wrapper(const std::vector<Eigen::Vector3d> &p1,
+						const std::vector<Eigen::Vector3d> &x1,
+						const std::vector<Eigen::Vector3d> &p2,
+						const std::vector<Eigen::Vector3d> &x2) {
+    std::vector<CameraPose> output;
+    gen_relpose_6pt(p1, x1, p2, x2, &output);
+    return output;
+}
+
 std::vector<CameraPose> relpose_upright_planar_2pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                            const std::vector<Eigen::Vector3d> &x2) {
     std::vector<CameraPose> output;
@@ -778,6 +787,8 @@ PYBIND11_MODULE(poselib, m) {
     m.def("essential_matrix_8pt", &poselib::essential_matrix_8pt_wrapper, py::arg("x1"), py::arg("x2"));
     m.def("relpose_upright_3pt", &poselib::relpose_upright_3pt_wrapper, py::arg("x1"), py::arg("x2"));
     m.def("gen_relpose_upright_4pt", &poselib::gen_relpose_upright_4pt_wrapper, py::arg("p1"), py::arg("x1"),
+          py::arg("p2"), py::arg("x2"));
+    m.def("gen_relpose_6pt", &poselib::gen_relpose_6pt_wrapper, py::arg("p1"), py::arg("x1"),
           py::arg("p2"), py::arg("x2"));
     m.def("relpose_upright_planar_2pt", &poselib::relpose_upright_planar_2pt_wrapper, py::arg("x1"), py::arg("x2"));
     m.def("relpose_upright_planar_3pt", &poselib::relpose_upright_planar_3pt_wrapper, py::arg("x1"), py::arg("x2"));


### PR DESCRIPTION
Thanks for replying to my issue :)
I added the gen_relpose_6pt wrapper to pyposelib.cpp referring to other wrappers.
I was worried if gen_relpose_6pt is incomplete, but it works fine!
Thank you again for your marvelous code!

The list for available modules in poselib:
__name__
__doc__
__package__
__loader__
__spec__
CameraPose
PairwiseMatches
p3p
gp3p
gp4ps
gp4ps_kukelova
gp4ps_camposeco
p4pf
p2p2pl
p6lp
p5lp_radial
p2p1ll
p1p2ll
p3ll
up2p
ugp2p
ugp3ps
up1p2pl
up4pl
ugp4pl
essential_matrix_5pt
relpose_5pt
relpose_8pt
essential_matrix_8pt
relpose_upright_3pt
gen_relpose_upright_4pt
gen_relpose_6pt
relpose_upright_planar_2pt
relpose_upright_planar_3pt
estimate_absolute_pose
estimate_absolute_pose_pnpl
estimate_generalized_absolute_pose
estimate_relative_pose
estimate_fundamental
estimate_homography
estimate_generalized_relative_pose
estimate_hybrid_pose
estimate_1D_radial_absolute_pose
refine_absolute_pose
refine_absolute_pose_pnpl
refine_generalized_absolute_pose
refine_relative_pose
refine_homography
refine_fundamental
refine_generalized_relative_pose
RansacOptions
BundleOptions
__version__
__file__

