### PR TITLE
Fix clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,5 +32,5 @@ else()
 	target_compile_options(${LIBRARY_NAME} PRIVATE
 		-march=native -ffast-math -fno-unsafe-math-optimizations
 		-funroll-loops -fprefetch-loop-arrays -funswitch-loops
-	 	-Wall -Werror -fPIC)
+	 	-Wall -Werror -fPIC -Wno-ignored-optimization-argument)
 endif()


### PR DESCRIPTION
Disables warnings for ignored optimization arguments. I tried to build with clang but it fails because `-fprefetch-loop-arrays` and `-funswitch-loops` are ignored and that generates an error. This MR fixes the issue.

Output building with clang 10.0:
```
[ 26%] Building CXX object PoseLib/CMakeFiles/PoseLib.dir/solvers/ugp2p.cc.o
[ 29%] Building CXX object PoseLib/CMakeFiles/PoseLib.dir/solvers/ugp3ps.cc.o
clang: error: optimization flag '-fprefetch-loop-arrays' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-funswitch-loops' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-fprefetch-loop-arrays' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-funswitch-loops' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-fprefetch-loop-arrays' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-funswitch-loops' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-fprefetch-loop-arrays' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-funswitch-loops' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-fprefetch-loop-arrays' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-funswitch-loops' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-fprefetch-loop-arrays' is not supported [-Werror,-Wignored-optimization-argument]
clang: error: optimization flag '-funswitch-loops' is not supported [-Werror,-Wignored-optimization-argument]
make[2]: *** [PoseLib/CMakeFiles/PoseLib.dir/build.make:118: PoseLib/CMakeFiles/PoseLib.dir/solvers/p2p1ll.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```