### PR TITLE
Add a p3p solver from "Revisiting the P3P Problem, CVPR 2023"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,8 @@ else()
 		-march=native -ffast-math -fno-unsafe-math-optimizations
 		-funroll-loops -fprefetch-loop-arrays -funswitch-loops
 	 	-Wall -Werror -fPIC -Wno-ignored-optimization-argument)
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		target_compile_options(${LIBRARY_NAME} PRIVATE
+				-Wno-maybe-uninitialized)
+	endif()
 endif()

--- a/PoseLib/CMakeLists.txt
+++ b/PoseLib/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     solvers/p2p2pl.cc
     solvers/p3ll.cc
     solvers/p3p.cc
+    solvers/p3p_ding.cc
     solvers/p4pf.cc
     solvers/p5lp_radial.cc
     solvers/p6lp.cc
@@ -51,6 +52,7 @@ set(HEADERS_PUBLIC
     solvers/p2p2pl.h
     solvers/p3ll.h
     solvers/p3p.h
+    solvers/p3p_ding.h
     solvers/p4pf.h
     solvers/p5lp_radial.h
     solvers/p6lp.h

--- a/PoseLib/solvers/p3p.cc
+++ b/PoseLib/solvers/p3p.cc
@@ -28,6 +28,8 @@
 
 #include "p3p.h"
 
+#include "p3p_common.h"
+
 namespace poselib {
 
 // Computes the eigen decomposition of a 3x3 matrix given that one eigenvalue is zero.
@@ -60,31 +62,6 @@ void compute_eig3x3known0(const Eigen::Matrix3d &M, Eigen::Matrix3d &E, double &
 
     // This is never used so we don't compute it
     // E.col(2) = M.col(1).cross(M.col(2)).normalized();
-}
-
-// Performs a few newton steps on the equations
-inline void refine_lambda(double &lambda1, double &lambda2, double &lambda3, const double a12, const double a13,
-                          const double a23, const double b12, const double b13, const double b23) {
-
-    for (int iter = 0; iter < 5; ++iter) {
-        double r1 = (lambda1 * lambda1 - 2.0 * lambda1 * lambda2 * b12 + lambda2 * lambda2 - a12);
-        double r2 = (lambda1 * lambda1 - 2.0 * lambda1 * lambda3 * b13 + lambda3 * lambda3 - a13);
-        double r3 = (lambda2 * lambda2 - 2.0 * lambda2 * lambda3 * b23 + lambda3 * lambda3 - a23);
-        if (std::abs(r1) + std::abs(r2) + std::abs(r3) < 1e-10)
-            return;
-        double x11 = lambda1 - lambda2 * b12;
-        double x12 = lambda2 - lambda1 * b12;
-        double x21 = lambda1 - lambda3 * b13;
-        double x23 = lambda3 - lambda1 * b13;
-        double x32 = lambda2 - lambda3 * b23;
-        double x33 = lambda3 - lambda2 * b23;
-        double detJ = 0.5 / (x11 * x23 * x32 + x12 * x21 * x33); // half minus inverse determinant
-        // This uses the closed form of the inverse for the jacobean.
-        // Due to the zero elements this actually becomes quite nice.
-        lambda1 += (-x23 * x32 * r1 - x12 * x33 * r2 + x12 * x23 * r3) * detJ;
-        lambda2 += (-x21 * x33 * r1 + x11 * x33 * r2 - x11 * x23 * r3) * detJ;
-        lambda3 += (x21 * x32 * r1 - x11 * x32 * r2 - x12 * x21 * r3) * detJ;
-    }
 }
 
 // Solves for camera pose such that: lambda*x = R*X+t  with positive lambda.

--- a/PoseLib/solvers/p3p_common.h
+++ b/PoseLib/solvers/p3p_common.h
@@ -1,0 +1,35 @@
+#ifndef POSELIB_P3P_COMMON_H
+#define POSELIB_P3P_COMMON_H
+
+#include <cmath>
+
+namespace poselib {
+
+// Performs a few newton steps on the equations
+inline void refine_lambda(double &lambda1, double &lambda2, double &lambda3, const double a12, const double a13,
+                          const double a23, const double b12, const double b13, const double b23) {
+
+    for (int iter = 0; iter < 5; ++iter) {
+        double r1 = (lambda1 * lambda1 - 2.0 * lambda1 * lambda2 * b12 + lambda2 * lambda2 - a12);
+        double r2 = (lambda1 * lambda1 - 2.0 * lambda1 * lambda3 * b13 + lambda3 * lambda3 - a13);
+        double r3 = (lambda2 * lambda2 - 2.0 * lambda2 * lambda3 * b23 + lambda3 * lambda3 - a23);
+        if (std::abs(r1) + std::abs(r2) + std::abs(r3) < 1e-10)
+            return;
+        double x11 = lambda1 - lambda2 * b12;
+        double x12 = lambda2 - lambda1 * b12;
+        double x21 = lambda1 - lambda3 * b13;
+        double x23 = lambda3 - lambda1 * b13;
+        double x32 = lambda2 - lambda3 * b23;
+        double x33 = lambda3 - lambda2 * b23;
+        double detJ = 0.5 / (x11 * x23 * x32 + x12 * x21 * x33); // half minus inverse determinant
+        // This uses the closed form of the inverse for the jacobean.
+        // Due to the zero elements this actually becomes quite nice.
+        lambda1 += (-x23 * x32 * r1 - x12 * x33 * r2 + x12 * x23 * r3) * detJ;
+        lambda2 += (-x21 * x33 * r1 + x11 * x33 * r2 - x11 * x23 * r3) * detJ;
+        lambda3 += (x21 * x32 * r1 - x11 * x32 * r2 - x12 * x21 * r3) * detJ;
+    }
+}
+
+} // namespace poselib
+
+#endif // POSELIB_P3P_COMMON_H

--- a/PoseLib/solvers/p3p_ding.cc
+++ b/PoseLib/solvers/p3p_ding.cc
@@ -143,7 +143,7 @@ void compute_pose(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen
 
 int p3p_ding(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
              std::vector<CameraPose> *output) {
-    if (output != nullptr) {
+    if (output == nullptr) {
         return 0;
     }
     output->clear();

--- a/PoseLib/solvers/p3p_ding.cc
+++ b/PoseLib/solvers/p3p_ding.cc
@@ -42,7 +42,7 @@ double cubic_trigonometric_solution(const double alpha, const double beta, const
     return 2.0 * I * K - k2 / 3.0;
 }
 
-double cubic_Cardano_solution(const double beta, const double G, const double k2) {
+double cubic_cardano_solution(const double beta, const double G, const double k2) {
     const double M = std::cbrt(-0.5 * beta + sqrt(G));
     const double N = -std::cbrt(0.5 * beta + sqrt(G));
     return M + N - k2 / 3.0;
@@ -143,6 +143,9 @@ void compute_pose(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen
 
 int p3p_ding(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
              std::vector<CameraPose> *output) {
+    if (!output) {
+        return 0;
+    }
     output->clear();
     output->reserve(4);
 
@@ -171,7 +174,7 @@ int p3p_ding(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vec
         if (G < 0) {
             s = cubic_trigonometric_solution(alpha, beta, k2);
         } else {
-            s = cubic_Cardano_solution(beta, G, k2);
+            s = cubic_cardano_solution(beta, G, k2);
         }
     } else {
         s = -k2 / 3.0 + (alpha != 0 ? (3.0 * beta / alpha) : 0);

--- a/PoseLib/solvers/p3p_ding.cc
+++ b/PoseLib/solvers/p3p_ding.cc
@@ -1,0 +1,203 @@
+// Copyright (c) 2020, Viktor Larsson
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of the copyright holder nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Author: Mark Shachkov (mark.shachkov@gmail.com)
+
+#include "p3p_ding.h"
+
+#include "p3p_common.h"
+
+namespace poselib {
+
+double cubic_trigonometric_solution(const double alpha, const double beta, const double k2) {
+    const double H = std::sqrt(-alpha * alpha * alpha / 27.0);
+    const double I = std::sqrt(-alpha / 3.0);
+    const double J = std::acos(-beta / (2.0 * H));
+    const double K = std::cos(J / 3.0);
+    return 2.0 * I * K - k2 / 3.0;
+}
+
+double cubic_Cardano_solution(const double beta, const double G, const double k2) {
+    const double M = std::cbrt(-0.5 * beta + sqrt(G));
+    const double N = -std::cbrt(0.5 * beta + sqrt(G));
+    return M + N - k2 / 3.0;
+}
+
+std::array<Eigen::Vector3d, 2> compute_pq(const double s, const double a, const double b, const double m12,
+                                          const double m13, const double m23) {
+    std::array<Eigen::Vector3d, 2> pq;
+    Eigen::Matrix3d C, C_adj;
+
+    C(0, 0) = -a + s * (1 - b);
+    C(0, 1) = -m13 * s;
+    C(0, 2) = a * m23 + b * m23 * s;
+    C(1, 0) = -m13 * s;
+    C(1, 1) = s + 1;
+    C(1, 2) = -m12;
+    C(2, 0) = a * m23 + b * m23 * s;
+    C(2, 1) = -m12;
+    C(2, 2) = -a - b * s + 1;
+
+    C_adj(0, 0) = -C({1, 2}, {1, 2}).determinant();
+    C_adj(1, 1) = -C({0, 2}, {0, 2}).determinant();
+    C_adj(2, 2) = -C({0, 1}, {0, 1}).determinant();
+    C_adj(0, 1) = C({0, 2}, {1, 2}).determinant();
+    C_adj(0, 2) = -C({0, 1}, {1, 2}).determinant();
+    C_adj(1, 0) = C({1, 2}, {0, 2}).determinant();
+    C_adj(1, 2) = C({0, 1}, {0, 2}).determinant();
+    C_adj(2, 0) = -C({1, 2}, {0, 1}).determinant();
+    C_adj(2, 1) = C({0, 2}, {0, 1}).determinant();
+
+    Eigen::Vector3d v;
+    if (C_adj(0, 0) > C_adj(1, 1)) {
+        if (C_adj(0, 0) > C_adj(2, 2)) {
+            v = C_adj.col(0) / std::sqrt(C_adj(0, 0));
+        } else {
+            v = C_adj.col(2) / std::sqrt(C_adj(2, 2));
+        }
+    } else if (C_adj(1, 1) > C_adj(2, 2)) {
+        v = C_adj.col(1) / std::sqrt(C_adj(1, 1));
+    } else {
+        v = C_adj.col(2) / std::sqrt(C_adj(2, 2));
+    }
+
+    Eigen::Matrix3d D = C;
+    D(0, 1) -= v(2);
+    D(0, 2) += v(1);
+    D(1, 2) -= v(0);
+    D(1, 0) += v(2);
+    D(2, 0) -= v(1);
+    D(2, 1) += v(0);
+
+    pq[0] = D.col(0);
+    pq[1] = D.row(0);
+
+    return pq;
+}
+
+std::pair<int, std::array<double, 2>> compute_line_conic_intersection(Eigen::Vector3d &l, const double b,
+                                                                      const double m13, const double m23) {
+    std::pair<int, std::array<double, 2>> result;
+    const double cxa = -b * l(1) * l(1) + l(2) * l(2);
+    const double cxb = -2 * b * m23 * l(1) * l(2) - 2 * b * l(0) * l(1) - 2 * m13 * l(2) * l(2);
+    const double cxc = -2 * b * m23 * l(0) * l(2) - b * l(0) * l(0) - b * l(2) * l(2) + l(2) * l(2);
+    const double d = cxb * cxb - 4 * cxa * cxc;
+
+    if (d < 0) {
+        result.first = 0;
+        return result;
+    }
+
+    result.second[0] = (-cxb + std::sqrt(d)) / (2.0 * cxa);
+    result.second[1] = (-cxb - std::sqrt(d)) / (2.0 * cxa);
+    result.first = d > 0 ? 2 : 1;
+    return result;
+}
+
+void compute_pose(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X, const double a12,
+                  const double a13, const double a23, const double m12, const double m13, const double m23,
+                  const double x_root, const double y_root, std::vector<CameraPose> *output) {
+    double d3 = std::sqrt(a13) / std::sqrt(x_root * x_root - 2 * m13 * x_root + 1);
+    double d2 = y_root * d3;
+    double d1 = x_root * d3;
+
+    refine_lambda(d1, d2, d3, a12, a13, a23, m12, m13, m23);
+
+    Eigen::Matrix3d A, B;
+    A.col(0) = X[0] - X[1];
+    A.col(1) = X[2] - X[0];
+    A.col(2) = (X[0] - X[1]).cross(X[2] - X[0]);
+    B.col(0) = d1 * x[0] - d2 * x[1];
+    B.col(1) = d3 * x[2] - d1 * x[0];
+    B.col(2) = B.col(0).cross(B.col(1));
+
+    Eigen::Matrix3d R = B * A.inverse();
+    Eigen::Vector3d t = d1 * x[0] - R * X[0];
+    output->emplace_back(R, t);
+}
+
+int p3p_ding(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
+             std::vector<CameraPose> *output) {
+    output->clear();
+    output->reserve(4);
+
+    const double a12 = (X[0] - X[1]).squaredNorm();
+    const double a13 = (X[0] - X[2]).squaredNorm();
+    const double a23 = (X[1] - X[2]).squaredNorm();
+    const double a = a12 / a23;
+    const double b = a13 / a23;
+
+    const double m12 = x[0].dot(x[1]);
+    const double m13 = x[0].dot(x[2]);
+    const double m23 = x[1].dot(x[2]);
+
+    const double k3_inv = 1.0 / (b * (-b * m23 * m23 + b + m13 * m13 - 1));
+    const double k2 = k3_inv * (-2 * a * b * m23 * m23 + 2 * a * b + a * m13 * m13 - a - b * b * m23 * m23 + b * b +
+                                2 * b * m12 * m13 * m23 - 2 * b - m13 * m13 + 1);
+    const double k1 = k3_inv * (-a * a * m23 * m23 + a * a - 2 * a * b * m23 * m23 + 2 * a * b +
+                                2 * a * m12 * m13 * m23 - 2 * a + b * m12 * m12 - b - m12 * m12 + 1);
+    const double k0 = k3_inv * (a * (-a * m23 * m23 + a + m12 * m12 - 1));
+    const double alpha = k1 - 1.0 / 3.0 * k2 * k2;
+    const double beta = k0 - 1.0 / 3.0 * k1 * k2 + (2.0 / 27.0) * k2 * k2 * k2;
+    const double G = beta * beta / 4.0 + alpha * alpha * alpha / 27.0;
+
+    double s;
+    if (G != 0) {
+        if (G < 0) {
+            s = cubic_trigonometric_solution(alpha, beta, k2);
+        } else {
+            s = cubic_Cardano_solution(beta, G, k2);
+        }
+    } else {
+        s = -k2 / 3.0 + (alpha != 0 ? (3.0 * beta / alpha) : 0);
+    }
+
+    std::array<Eigen::Vector3d, 2> pq = compute_pq(s, a, b, m12, m13, m23);
+
+    for (int i = 0; i < 2; i++) {
+        auto [n_roots, x_roots] = compute_line_conic_intersection(pq[i], b, m13, m23);
+        for (int j = 0; j < n_roots; j++) {
+            const double x_root = x_roots[j];
+            const double y_root = (-pq[i](0) - pq[i](1) * x_root) / pq[i](2);
+            if (x_root <= 0 || y_root <= 0) {
+                continue;
+            }
+            compute_pose(x, X, a12, a13, a23, m12, m13, m23, x_root, y_root, output);
+        }
+
+        if ((G == 0) | (G < 0 ? n_roots : !n_roots)) {
+            continue;
+        }
+
+        break;
+    }
+
+    return output->size();
+}
+
+} // namespace poselib

--- a/PoseLib/solvers/p3p_ding.cc
+++ b/PoseLib/solvers/p3p_ding.cc
@@ -143,7 +143,7 @@ void compute_pose(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen
 
 int p3p_ding(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
              std::vector<CameraPose> *output) {
-    if (!output) {
+    if (output != nullptr) {
         return 0;
     }
     output->clear();

--- a/PoseLib/solvers/p3p_ding.h
+++ b/PoseLib/solvers/p3p_ding.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2020, Viktor Larsson
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of the copyright holder nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef POSELIB_P3P_DING_H_
+#define POSELIB_P3P_DING_H_
+
+#include "PoseLib/camera_pose.h"
+
+#include <Eigen/Dense>
+#include <vector>
+
+namespace poselib {
+
+// Solves for camera pose such that: lambda*x = R*X+t  with positive lambda.
+// Re-implementation of the P3P solver from
+//    Y. Ding, J. Yang, V. Larsson, C. Olsson, K. Åström, Revisiting the P3P Problem, CVPR 2023
+// Note: this impl. assumes that x has been normalized.
+int p3p_ding(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
+             std::vector<CameraPose> *output);
+
+} // namespace poselib
+
+#endif

--- a/PoseLib/solvers/relpose_8pt.cc
+++ b/PoseLib/solvers/relpose_8pt.cc
@@ -31,6 +31,7 @@
 #include "PoseLib/misc/essential.h"
 
 #include <array>
+#include <cassert>
 
 /**
  * Build a 9 x n matrix from bearing vector matches, where each row is equivalent to the

--- a/benchmark/benchmark.cc
+++ b/benchmark/benchmark.cc
@@ -31,15 +31,14 @@ template <typename Solver> BenchmarkResult benchmark(int n_problems, const Probl
         double pose_error = std::numeric_limits<double>::max();
 
         result.solutions_ += sols;
-        // std::cout << "\nGt: " << instance.pose_gt.R << "\n"<< instance.pose_gt.t << "\n";
+        // std::cout << "\nGt: " << instance.pose_gt.R() << "\n"<< instance.pose_gt.t << "\n";
         // std::cout << "gt valid = " << Solver::validator::is_valid(instance, instance.pose_gt, 1.0, tol) << "\n";
         for (const CameraPose &pose : solutions) {
             if (Solver::validator::is_valid(instance, pose, 1.0, tol))
                 result.valid_solutions_++;
-            // std::cout << "Pose: " << pose.R << "\n" << pose.t << "\n";
+            // std::cout << "Pose: " << pose.R() << "\n" << pose.t << "\n";
             pose_error = std::min(pose_error, Solver::validator::compute_pose_error(instance, pose, 1.0));
         }
-
         if (pose_error < tol)
             result.found_gt_pose_++;
     }
@@ -47,14 +46,10 @@ template <typename Solver> BenchmarkResult benchmark(int n_problems, const Probl
     std::vector<long> runtimes;
     CameraPoseVector solutions;
     for (int iter = 0; iter < 10; ++iter) {
-        int total_sols = 0;
         auto start_time = std::chrono::high_resolution_clock::now();
         for (const AbsolutePoseProblemInstance &instance : problem_instances) {
             solutions.clear();
-
-            int sols = Solver::solve(instance, &solutions);
-
-            total_sols += sols;
+            Solver::solve(instance, &solutions);
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -106,15 +101,12 @@ BenchmarkResult benchmark_w_extra(int n_problems, const ProblemOptions &options,
     CameraPoseVector solutions;
     std::vector<double> extra;
     for (int iter = 0; iter < 10; ++iter) {
-        int total_sols = 0;
         auto start_time = std::chrono::high_resolution_clock::now();
         for (const AbsolutePoseProblemInstance &instance : problem_instances) {
             solutions.clear();
             extra.clear();
 
-            int sols = Solver::solve(instance, &solutions, &extra);
-
-            total_sols += sols;
+            Solver::solve(instance, &solutions, &extra);
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -166,14 +158,11 @@ BenchmarkResult benchmark_relative(int n_problems, const ProblemOptions &options
     std::vector<long> runtimes;
     CameraPoseVector solutions;
     for (int iter = 0; iter < 10; ++iter) {
-        int total_sols = 0;
         auto start_time = std::chrono::high_resolution_clock::now();
         for (const RelativePoseProblemInstance &instance : problem_instances) {
             solutions.clear();
 
-            int sols = Solver::solve(instance, &solutions);
-
-            total_sols += sols;
+            Solver::solve(instance, &solutions);
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -226,14 +215,11 @@ BenchmarkResult benchmark_homography(int n_problems, const ProblemOptions &optio
     std::vector<long> runtimes;
     std::vector<Eigen::Matrix3d> solutions;
     for (int iter = 0; iter < 10; ++iter) {
-        int total_sols = 0;
         auto start_time = std::chrono::high_resolution_clock::now();
         for (const RelativePoseProblemInstance &instance : problem_instances) {
             solutions.clear();
 
-            int sols = Solver::solve(instance, &solutions);
-
-            total_sols += sols;
+            Solver::solve(instance, &solutions);
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -312,6 +298,7 @@ int main() {
     p3p_opt.n_point_point_ = 3;
     p3p_opt.n_point_line_ = 0;
     results.push_back(poselib::benchmark<poselib::SolverP3P>(1e5, p3p_opt, tol));
+    results.push_back(poselib::benchmark<poselib::SolverP3P_ding>(1e5, p3p_opt, tol));
 
     // gP3P
     poselib::ProblemOptions gp3p_opt = options;

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -30,6 +30,14 @@ struct SolverP3P {
     static std::string name() { return "p3p"; }
 };
 
+struct SolverP3P_ding {
+    static inline int solve(const AbsolutePoseProblemInstance &instance, poselib::CameraPoseVector *solutions) {
+        return p3p_ding(instance.x_point_, instance.X_point_, solutions);
+    }
+    typedef CalibPoseValidator validator;
+    static std::string name() { return "p3p_ding"; }
+};
+
 struct SolverP4PF {
     static inline int solve(const AbsolutePoseProblemInstance &instance, poselib::CameraPoseVector *solutions,
                             std::vector<double> *focals) {

--- a/benchmark/problem_generator.cc
+++ b/benchmark/problem_generator.cc
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <random>
 #include <vector>
+#include <cassert>
 
 namespace poselib {
 


### PR DESCRIPTION
This PR introduce an implementation of p3p solver described in "Y. Ding, J. Yang, V. Larsson, C. Olsson, K. Åström, Revisiting the P3P Problem, CVPR 2023". If you find no issues with correctness/performance, then i can rework this PR to substitute current implementation of p3p (Lambda Twist).

                    Solver    Solutions        Valid     GT found      Runtime
                       p3p      1.72803          100          100    270.85 ns
                  p3p_ding      1.72803          100          100   215.699 ns