### PR TITLE
fix build error: duplicate symbol 'poselib_info()'

### DIFF
--- a/PoseLib/poselib.h.in
+++ b/PoseLib/poselib.h.in
@@ -12,7 +12,7 @@
 
 
 // Print PoseLib version and buidling type
-std::string poselib_info(void) {
+inline std::string poselib_info(void) {
     #if (POSELIB_DEBUG)
         const std::string build_type = "DEBUG";
     #else


### PR DESCRIPTION
when I intergrade PoseLib to my own slam code, clang has give me this error:
```
[build] duplicate symbol 'poselib_info()' in:
[build]     CMakeFiles/re0slam.dir/Debug/run.cc.o
[build]     CMakeFiles/re0slam.dir/Debug/slam.cc.o
[build] duplicate symbol 'poselib_info()' in:
[build]     CMakeFiles/re0slam.dir/Debug/run.cc.o
[build]     CMakeFiles/re0slam.dir/Debug/frame.cc.o
[build] ld: 2 duplicate symbols for architecture arm64
[build] clang: error: linker command failed with exit code 1 (use -v to see invocation)
[build] ninja: build stopped: subcommand failed.
``` 

this caused by 'poselib_info' defined in a header file; function definitions in header files can lead to ODR violations (fix available), add `inline` to avoid it.