### PR TITLE
Remove fp:fast from msvc flags to match the removal of gcc -ffast-math.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(PoseLib VERSION 2.0.5)
 # Compilation flags function
 function(set_compile_flags build_target)
 if(MSVC)
-	target_compile_options(${build_target} PRIVATE /bigobj /fp:fast)
+	target_compile_options(${build_target} PRIVATE /bigobj)
 else()
 	target_compile_options(${build_target} PRIVATE
 		-O3 -Wall -Werror -fPIC -Wno-sign-compare -Wfatal-errors)


### PR DESCRIPTION
The `-ffast-math` flag was removed from the UNIX build flags quite some time ago. 

The msvc flag stayed despite few performance gains.
`fp:precise` is the default and it makes reproducible results across debug and release.

This PR removes `fp:fast`.

https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170