### PR TITLE
Add missing include for robust/ransac_impl.h.

### DIFF
--- a/PoseLib/robust/ransac_impl.h
+++ b/PoseLib/robust/ransac_impl.h
@@ -29,6 +29,7 @@
 #ifndef POSELIB_RANSAC_IMPL_H_
 #define POSELIB_RANSAC_IMPL_H_
 
+#include "PoseLib/camera_pose.h"
 #include "PoseLib/types.h"
 
 #include <vector>


### PR DESCRIPTION
CameraPose is used as the default class in the template, but is not included in the header. This will result in error when one does ``#include <PoseLib/ransac/ransac_impl.h>`` alone without including ``PoseLib/camera_pose.h``. 