### PR TITLE
Implement NullCameraModel methods for projection and unprojection

### DIFF
--- a/PoseLib/misc/colmap_models.cc
+++ b/PoseLib/misc/colmap_models.cc
@@ -784,10 +784,23 @@ const std::vector<size_t> OpenCVFisheyeCameraModel::principal_point_idx = {2, 3}
 // Null camera - this is used as a dummy value in various places
 // params = {}
 
-void NullCameraModel::project(const std::vector<double> &params, const Eigen::Vector2d &x, Eigen::Vector2d *xp) {}
+void NullCameraModel::project(const std::vector<double> &params, const Eigen::Vector2d &x, Eigen::Vector2d *xp) {
+    (*xp)(0) = x(0);
+    (*xp)(1) = x(1);
+}
 void NullCameraModel::project_with_jac(const std::vector<double> &params, const Eigen::Vector2d &x, Eigen::Vector2d *xp,
-                                       Eigen::Matrix2d *jac) {}
-void NullCameraModel::unproject(const std::vector<double> &params, const Eigen::Vector2d &xp, Eigen::Vector2d *x) {}
+                                       Eigen::Matrix2d *jac) {
+    (*xp)(0) = x(0);
+    (*xp)(1) = x(1);
+    (*jac)(0, 0) = 1.0;
+    (*jac)(0, 1) = 0.0;
+    (*jac)(1, 0) = 0.0;
+    (*jac)(1, 1) = 1.0;
+}
+void NullCameraModel::unproject(const std::vector<double> &params, const Eigen::Vector2d &xp, Eigen::Vector2d *x) {
+    (*x)(0) = xp(0);
+    (*x)(1) = xp(1);
+}
 const std::vector<size_t> NullCameraModel::focal_idx = {};
 const std::vector<size_t> NullCameraModel::principal_point_idx = {};
 


### PR DESCRIPTION
This is an attempt to create a general camera type that can be used for example for relative pose estimation directly with unprojected coordinates, and so making it agnostic to the real camera type behind. Not only this should make poselib work with yet undefined camera models, like spherical camera, but also simplify the usage in a project that hosts multiple camera models and has already internal support for generating in a unified way (through virtual functions) the undistorted keypoint positions.
