### PR TITLE
Skip Python 3.14 in cibuildwheel

### DIFF
--- a/.github/workflows/build-pypi.yaml
+++ b/.github/workflows/build-pypi.yaml
@@ -35,7 +35,7 @@ jobs:
           
           CIBW_BEFORE_ALL_MACOS: brew install eigen
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "" # https://github.com/pypa/cibuildwheel/issues/1989
-          CIBW_SKIP: "*-musllinux_x86_64"
+          CIBW_SKIP: "*-musllinux_x86_64 cp314-*"
             
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
opencv-python lacks pre-built wheels for Python 3.14, causing macOS builds to fail on master.