### PR TITLE
Fix stub generation in pip isolated builds and add ruff Python formatting

### DIFF
--- a/pybind/CMakeLists.txt
+++ b/pybind/CMakeLists.txt
@@ -41,7 +41,7 @@ if(GENERATE_STUBS)
         COMMAND
           "${CMAKE_COMMAND}" -E env
           "PYTHONPATH=$<TARGET_FILE_DIR:pyposelib>$<SEMICOLON>$ENV{PYTHONPATH}"
-          "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${Python_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}"
+          "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating pybind11 stubs"
         VERBATIM

--- a/pybind/generate_stubs.py
+++ b/pybind/generate_stubs.py
@@ -7,7 +7,6 @@ Adapted from generate_stubs.sh to work on Windows, macOS, and Linux.
 import sys
 import subprocess
 import re
-import shutil
 from pathlib import Path
 
 
@@ -66,17 +65,16 @@ def main():
     for file_path in files_to_process:
         process_stub_file(file_path)
 
-    # Format with ruff if available
-    if shutil.which("ruff"):
-        print("Formatting stubs with ruff...")
-        try:
-            subprocess.run(
-                ["ruff", "format"] + [str(f) for f in files_to_process], check=False
-            )
-        except Exception as e:
-            print(f"Warning: ruff formatting failed: {e}")
-    else:
-        print("ruff not found, skipping formatting")
+    # Format with ruff if available (use sys.executable -m to work in isolated builds)
+    print("Formatting stubs with ruff...")
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "ruff", "format"]
+            + [str(f) for f in files_to_process],
+            check=False,
+        )
+    except Exception as e:
+        print(f"Warning: ruff formatting failed: {e}")
 
 
 def process_stub_file(file_path):

--- a/pybind/generate_stubs.py
+++ b/pybind/generate_stubs.py
@@ -5,7 +5,6 @@ Adapted from generate_stubs.sh to work on Windows, macOS, and Linux.
 """
 
 import sys
-import os
 import subprocess
 import re
 import shutil
@@ -13,39 +12,45 @@ from pathlib import Path
 
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python generate_stubs.py <python_executable> <output_dir>")
+    if len(sys.argv) != 2:
+        print("Usage: python generate_stubs.py <output_dir>")
         sys.exit(1)
-    
-    python_exec = sys.argv[1]
-    output_dir = Path(sys.argv[2])
+
+    python_exec = sys.executable
+    output_dir = Path(sys.argv[1])
     package_name = "_core"
-    
+
     print(f"Building stubs with {python_exec} to {output_dir}")
-    
+
     # Run pybind11_stubgen
     cmd = [
-        python_exec, "-m", "pybind11_stubgen", package_name,
-        "-o", str(output_dir),
+        python_exec,
+        "-m",
+        "pybind11_stubgen",
+        package_name,
+        "-o",
+        str(output_dir),
         "--numpy-array-use-type-var",
         f"--enum-class-locations=.+:{package_name}",
-        "--ignore-invalid-expressions", "poselib::*",
+        "--ignore-invalid-expressions",
+        "poselib::*",
         "--print-invalid-expressions-as-is",
-        "--print-safe-value-reprs", "[a-zA-Z]+Options\\(\\)"
+        "--print-safe-value-reprs",
+        "[a-zA-Z]+Options\\(\\)",
     ]
-    
+
     try:
         subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
         print(f"Error running pybind11_stubgen: {e}")
         sys.exit(1)
-    
+
     # Find the generated stub files
     stub_file = output_dir / f"{package_name}.pyi"
     stub_dir = output_dir / package_name
-    
+
     files_to_process = []
-    
+
     if stub_file.exists():
         files_to_process = [stub_file]
     elif stub_dir.exists():
@@ -56,16 +61,18 @@ def main():
         for item in output_dir.iterdir():
             print(f"  {item}")
         sys.exit(1)
-    
+
     # Process each stub file
     for file_path in files_to_process:
         process_stub_file(file_path)
-    
+
     # Format with ruff if available
     if shutil.which("ruff"):
         print("Formatting stubs with ruff...")
         try:
-            subprocess.run(["ruff", "format"] + [str(f) for f in files_to_process], check=False)
+            subprocess.run(
+                ["ruff", "format"] + [str(f) for f in files_to_process], check=False
+            )
         except Exception as e:
             print(f"Warning: ruff formatting failed: {e}")
     else:
@@ -75,14 +82,14 @@ def main():
 def process_stub_file(file_path):
     """Apply regex replacements to clean up the stub file."""
     print(f"Processing {file_path}")
-    
-    with open(file_path, 'r', encoding='utf-8') as f:
+
+    with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
-    content = re.sub(r'\b_core.\b', '', content)
-    
-    with open(file_path, 'w', encoding='utf-8') as f:
+    content = re.sub(r"\b_core.\b", "", content)
+
+    with open(file_path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/pyposelib/__init__.py
+++ b/pyposelib/__init__.py
@@ -23,9 +23,7 @@ except ImportError as e:
 if TYPE_CHECKING:
     from ._core import *  # noqa F403
 
-__all__ = import_module_symbols(
-    globals(), _core, exclude=set()
-)
+__all__ = import_module_symbols(globals(), _core, exclude=set())
 __all__.extend(["__version__"])
 
-__version__ = _core.__version__ 
+__version__ = _core.__version__

--- a/pyposelib/utils.py
+++ b/pyposelib/utils.py
@@ -2,10 +2,10 @@ def import_module_symbols(globals_dict, module, exclude=None):
     """Import all public symbols from a module into globals."""
     if exclude is None:
         exclude = set()
-    
+
     symbols = []
     for name in dir(module):
-        if not name.startswith('_') and name not in exclude:
+        if not name.startswith("_") and name not in exclude:
             globals_dict[name] = getattr(module, name)
             symbols.append(name)
-    return symbols 
+    return symbols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel>=0.38", "pybind11==3.0.1", "pybind11-stubgen", "ruff==0.15.0", "numpy"]
+requires = ["setuptools>=68", "wheel>=0.38", "pybind11==3.0.1", "pybind11-stubgen==2.5.1", "ruff==0.15.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -31,6 +31,7 @@ license-files = ["LICENSE"]
 [dependency-groups]
 dev = [
     "clang-format==21.1.8",
+    "ruff==0.15.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel>=0.38", "pybind11==3.0.1", "pybind11-stubgen", "ruff", "numpy"]
+requires = ["setuptools>=68", "wheel>=0.38", "pybind11==3.0.1", "pybind11-stubgen", "ruff==0.15.0", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -32,3 +32,10 @@ license-files = ["LICENSE"]
 dev = [
     "clang-format==21.1.8",
 ]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.format]
+indent-style = "space"

--- a/scripts/ruff_format.sh
+++ b/scripts/ruff_format.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Check ruff is available
+if ! command -v ruff &> /dev/null; then
+    echo "ruff not found. Please install it: pip install ruff"
+    exit 1
+fi
+
+echo "Using $(ruff --version)"
+
 # Determine script absolute path
 SCRIPT_ABS_PATH=$(readlink -f ${BASH_SOURCE[0]})
 SCRIPT_ABS_PATH=$(dirname ${SCRIPT_ABS_PATH})
 
 # root folder
-ROOT="$(readlink -f ${SCRIPT_ABS_PATH}/..)"
+ROOT="$(readlink -f "${SCRIPT_ABS_PATH}"/..)"
 
-echo "Using $(ruff --version)"
-
-ruff check --fix ${ROOT}
-ruff format ${ROOT}
+ruff check --fix "${ROOT}"
+ruff format "${ROOT}"

--- a/scripts/ruff_format.sh
+++ b/scripts/ruff_format.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine script absolute path
+SCRIPT_ABS_PATH=$(readlink -f ${BASH_SOURCE[0]})
+SCRIPT_ABS_PATH=$(dirname ${SCRIPT_ABS_PATH})
+
+# root folder
+ROOT="$(readlink -f ${SCRIPT_ABS_PATH}/..)"
+
+echo "Using $(ruff --version)"
+
+ruff check --fix ${ROOT}
+ruff format ${ROOT}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from distutils.version import LooseVersion
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
+    def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
@@ -18,14 +18,18 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            out = subprocess.check_output(["cmake", "--version"])
         except OSError:
-            raise RuntimeError("CMake must be installed to build the following extensions: " +
-                               ", ".join(e.name for e in self.extensions))
+            raise RuntimeError(
+                "CMake must be installed to build the following extensions: "
+                + ", ".join(e.name for e in self.extensions)
+            )
 
         if platform.system() == "Windows":
-            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
-            if cmake_version < '3.1.0':
+            cmake_version = LooseVersion(
+                re.search(r"version\s*([\d.]+)", out.decode()).group(1)
+            )
+            if cmake_version < "3.1.0":
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:
@@ -33,48 +37,58 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DPython_EXECUTABLE=' + sys.executable,
-                      '-DPYTHON_PACKAGE=ON',
-                      '-DBUILD_SHARED_LIBS=OFF',]
-        if os.environ.get('CMAKE_INSTALL_PREFIX') is not None:
-            cmake_args += [f"-DCMAKE_INSTALL_PREFIX={os.environ.get('CMAKE_INSTALL_PREFIX')}"]
+        cmake_args = [
+            "-DPython_EXECUTABLE=" + sys.executable,
+            "-DPYTHON_PACKAGE=ON",
+            "-DBUILD_SHARED_LIBS=OFF",
+        ]
+        if os.environ.get("CMAKE_INSTALL_PREFIX") is not None:
+            cmake_args += [
+                f"-DCMAKE_INSTALL_PREFIX={os.environ.get('CMAKE_INSTALL_PREFIX')}"
+            ]
         else:
             # Set the install prefix to the extension directory so install() commands work
             cmake_args += [f"-DCMAKE_INSTALL_PREFIX={extdir}"]
-            
-        cfg = 'Debug' if self.debug else 'Release'
-        build_args = ['--config', cfg]
+
+        cfg = "Debug" if self.debug else "Release"
+        build_args = ["--config", cfg]
 
         if platform.system() == "Windows":
-            if os.environ.get('CMAKE_TOOLCHAIN_FILE') is not None:
-                cmake_toolchain_file = os.environ.get('CMAKE_TOOLCHAIN_FILE')
-                cmake_args += [f'-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain_file}']
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            if os.environ.get("CMAKE_TOOLCHAIN_FILE") is not None:
+                cmake_toolchain_file = os.environ.get("CMAKE_TOOLCHAIN_FILE")
+                cmake_args += [f"-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain_file}"]
+            cmake_args += [
+                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
+            ]
             if sys.maxsize > 2**32:
-                if os.environ.get('CMAKE_TOOLCHAIN_FILE') is not None:
-                    cmake_args += ['-DVCPKG_TARGET_TRIPLET=x64-windows']
-                cmake_args += ['-A', 'x64']
-            build_args += ['--', '/m']
+                if os.environ.get("CMAKE_TOOLCHAIN_FILE") is not None:
+                    cmake_args += ["-DVCPKG_TARGET_TRIPLET=x64-windows"]
+                cmake_args += ["-A", "x64"]
+            build_args += ["--", "/m"]
         else:
-            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j2']
+            cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+            build_args += ["--", "-j2"]
 
         env = os.environ.copy()
-        
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(
-            env.get('CXXFLAGS', ''),
-            self.distribution.get_version()
+
+        env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
+            env.get("CXXFLAGS", ""), self.distribution.get_version()
         )
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
-        
-        # Run cmake --install but only install the python component to avoid library headers/libs
-        install_args = ['--config', cfg] if platform.system() == "Windows" else []
-        install_args += ['--component', 'python']
-        subprocess.check_call(['cmake', '--install', '.'] + install_args, cwd=self.build_temp)
+        subprocess.check_call(
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
+        )
+        subprocess.check_call(
+            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+        )
 
+        # Run cmake --install but only install the python component to avoid library headers/libs
+        install_args = ["--config", cfg] if platform.system() == "Windows" else []
+        install_args += ["--component", "python"]
+        subprocess.check_call(
+            ["cmake", "--install", "."] + install_args, cwd=self.build_temp
+        )
 
 
 # The information here can also be placed in setup.cfg - better separation of

--- a/tests/test_poselib.py
+++ b/tests/test_poselib.py
@@ -1,17 +1,19 @@
 import sys
 import poselib
 
+
 def test_poselib():
-    print(f'Python version: {sys.version}')
-    print(f'PoseLib version: {poselib.__version__}')
+    print(f"Python version: {sys.version}")
+    print(f"PoseLib version: {poselib.__version__}")
     if sys.version_info < (3, 14):
         from posebench import run_benchmark
-        print(f'Running posebench...')
+
+        print("Running posebench...")
         result = run_benchmark(
             subset=True,
             only_poselib=True,
         )
         print(result)
-        print('Posebench done.')
+        print("Posebench done.")
     else:
-        print('Skipping tests for Python >= 3.14 due to deps not ready yet (h5py)')
+        print("Skipping tests for Python >= 3.14 due to deps not ready yet (h5py)")

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,7 @@ test = [
 [package.dev-dependencies]
 dev = [
     { name = "clang-format" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -252,7 +253,10 @@ requires-dist = [
 provides-extras = ["test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "clang-format", specifier = "==21.1.8" }]
+dev = [
+    { name = "clang-format", specifier = "==21.1.8" },
+    { name = "ruff", specifier = "==0.15.0" },
+]
 
 [[package]]
 name = "pygments"
@@ -279,6 +283,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Fix generate_stubs.py to use sys.executable instead of passing the Python path as an argument. During pip's isolated builds, this ensures pybind11_stubgen and numpy are found correctly.
* Add scripts/ruff_format.sh for Python formatting (mirrors scripts/clang_format.sh)
* Add ruff configuration to pyproject.toml
* Pin ruff==0.15.0 in build-requires