### PR TITLE
Fix the python executable for stubgen to be consistent.

### DIFF
--- a/pybind/CMakeLists.txt
+++ b/pybind/CMakeLists.txt
@@ -40,7 +40,7 @@ if(GENERATE_STUBS)
         TARGET pyposelib POST_BUILD
         COMMAND
           "${CMAKE_COMMAND}" -E env
-          "PYTHONPATH=$<TARGET_FILE_DIR:pyposelib>$<SEMICOLON>$ENV{PYTHONPATH}"
+          "PYTHONPATH=$<TARGET_FILE_DIR:pyposelib>$<SEMICOLON>${POSELIB_PYTHONPATH}"
           "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating pybind11 stubs"

--- a/pybind/CMakeLists.txt
+++ b/pybind/CMakeLists.txt
@@ -7,11 +7,6 @@ endif()
 find_package(Python REQUIRED COMPONENTS Interpreter ${DEV_MODULE})
 message(STATUS "Python_EXECUTABLE: " ${Python_EXECUTABLE})
 
-# Default Python interpreter for stub generation (can be overridden with -DSTUBGEN_PYTHON=...)
-if(NOT DEFINED STUBGEN_PYTHON OR STUBGEN_PYTHON STREQUAL "")
-    set(STUBGEN_PYTHON "${Python_EXECUTABLE}" CACHE FILEPATH "Python interpreter for stub generation")
-endif()
-
 option(GENERATE_STUBS "Whether to generate stubs" ON)
 
 # Find pybind11 from pip installation
@@ -46,7 +41,7 @@ if(GENERATE_STUBS)
         COMMAND
           "${CMAKE_COMMAND}" -E env
           "PYTHONPATH=$<TARGET_FILE_DIR:pyposelib>$<SEMICOLON>$ENV{PYTHONPATH}"
-          "${STUBGEN_PYTHON}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${CMAKE_CURRENT_BINARY_DIR}"
+          "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating pybind11 stubs"
         VERBATIM

--- a/pybind/CMakeLists.txt
+++ b/pybind/CMakeLists.txt
@@ -41,7 +41,7 @@ if(GENERATE_STUBS)
         COMMAND
           "${CMAKE_COMMAND}" -E env
           "PYTHONPATH=$<TARGET_FILE_DIR:pyposelib>$<SEMICOLON>$ENV{PYTHONPATH}"
-          "${Python_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${CMAKE_CURRENT_BINARY_DIR}"
+          "${STUBGEN_PYTHON}" "${PROJECT_SOURCE_DIR}/pybind/generate_stubs.py" "${CMAKE_CURRENT_BINARY_DIR}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating pybind11 stubs"
         VERBATIM

--- a/pybind/CMakeLists.txt
+++ b/pybind/CMakeLists.txt
@@ -7,6 +7,11 @@ endif()
 find_package(Python REQUIRED COMPONENTS Interpreter ${DEV_MODULE})
 message(STATUS "Python_EXECUTABLE: " ${Python_EXECUTABLE})
 
+# Default Python interpreter for stub generation (can be overridden with -DSTUBGEN_PYTHON=...)
+if(NOT DEFINED STUBGEN_PYTHON OR STUBGEN_PYTHON STREQUAL "")
+    set(STUBGEN_PYTHON "${Python_EXECUTABLE}" CACHE FILEPATH "Python interpreter for stub generation")
+endif()
+
 option(GENERATE_STUBS "Whether to generate stubs" ON)
 
 # Find pybind11 from pip installation

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ class CMakeBuild(build_ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
             "-DPython_EXECUTABLE=" + sys.executable,
+            "-DSTUBGEN_PYTHON=" + sys.executable,
             "-DPYTHON_PACKAGE=ON",
             "-DBUILD_SHARED_LIBS=OFF",
         ]

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ class CMakeBuild(build_ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
             "-DPython_EXECUTABLE=" + sys.executable,
+            "-DPOSELIB_PYTHONPATH=" + os.pathsep.join(sys.path),
             "-DPYTHON_PACKAGE=ON",
             "-DBUILD_SHARED_LIBS=OFF",
         ]
@@ -70,10 +71,6 @@ class CMakeBuild(build_ext):
             build_args += ["--", "-j2"]
 
         env = os.environ.copy()
-
-        # Propagate pip's build isolation paths so CMake subprocesses
-        # (e.g. stub generation) can find build-requires like pybind11_stubgen
-        env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
             env.get("CXXFLAGS", ""), self.distribution.get_version()

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ class CMakeBuild(build_ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = [
             "-DPython_EXECUTABLE=" + sys.executable,
-            "-DSTUBGEN_PYTHON=" + sys.executable,
             "-DPYTHON_PACKAGE=ON",
             "-DBUILD_SHARED_LIBS=OFF",
         ]
@@ -71,6 +70,10 @@ class CMakeBuild(build_ext):
             build_args += ["--", "-j2"]
 
         env = os.environ.copy()
+
+        # Propagate pip's build isolation paths so CMake subprocesses
+        # (e.g. stub generation) can find build-requires like pybind11_stubgen
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
         env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
             env.get("CXXFLAGS", ""), self.distribution.get_version()


### PR DESCRIPTION
Without this fix, the python executable for stubgen was still confused by find_package(Python). 